### PR TITLE
Restore car route when the map changes

### DIFF
--- a/src/Car.elm
+++ b/src/Car.elm
@@ -380,10 +380,8 @@ markAsConfused : Car -> Car
 markAsConfused car =
     { car
         | status = Confused
-        , velocity = Quantity.zero
-        , acceleration = Quantity.zero
+        , acceleration = maxDeceleration
         , route = []
-        , localPath = []
     }
 
 

--- a/src/Car.elm
+++ b/src/Car.elm
@@ -389,15 +389,28 @@ markAsConfused car =
 
 createRoute : RNNodeContext -> Car -> Car
 createRoute nodeCtx car =
+    let
+        newPathRequired =
+            case car.route of
+                target :: _ ->
+                    target.node.label.position /= nodeCtx.node.label.position
+
+                _ ->
+                    True
+    in
     { car
         | route = [ nodeCtx ]
         , localPath =
-            LocalPath.toNode
-                { origin = car.position
-                , direction = Direction2d.fromAngle car.orientation
-                , useOffsetSpline = car.status == ParkedAtLot
-                }
-                nodeCtx
+            if newPathRequired then
+                LocalPath.toNode
+                    { origin = car.position
+                    , direction = Direction2d.fromAngle car.orientation
+                    , useOffsetSpline = car.status == ParkedAtLot
+                    }
+                    nodeCtx
+
+            else
+                car.localPath
     }
 
 

--- a/src/Config.elm
+++ b/src/Config.elm
@@ -5,8 +5,6 @@ module Config exposing
     , borderRadius
     , borderSize
     , colors
-    , dequeueFrequency
-    , environmentUpdateFrequency
     , pixelsToMeters
     , pixelsToMetersRatio
     , tileSize
@@ -27,16 +25,6 @@ import Quantity exposing (Quantity, Rate)
 --
 
 
-environmentUpdateFrequency : Float
-environmentUpdateFrequency =
-    1000
-
-
-dequeueFrequency : Float
-dequeueFrequency =
-    500
-
-
 boardSize : Int
 boardSize =
     10
@@ -44,7 +32,7 @@ boardSize =
 
 
 --
--- Unit constants
+-- Pixels x meters conversion
 --
 
 

--- a/src/Lot.elm
+++ b/src/Lot.elm
@@ -12,12 +12,15 @@ module Lot exposing
     , entryDetails
     , fromNewLot
     , inBounds
+    , parkingSpotOrientation
     )
 
+import Angle exposing (Angle)
 import BoundingBox2d
 import Cell exposing (Cell, OrthogonalDirection(..))
 import Config exposing (tileSizeInMeters)
 import Dict exposing (Dict)
+import Direction2d
 import Entity exposing (Id)
 import Geometry exposing (LMBoundingBox2d, LMPoint2d)
 import Length exposing (Length)
@@ -225,6 +228,14 @@ parkingSpot anchor newLot =
             Vector2d.xy shiftX shiftY
     in
     origin |> Point2d.translateBy displacement
+
+
+parkingSpotOrientation : Lot -> Angle
+parkingSpotOrientation lot =
+    lot.content.entryDirection
+        |> Cell.orthogonalDirectionToLmDirection
+        |> Direction2d.rotateClockwise
+        |> Direction2d.toAngle
 
 
 entryCell : Anchor -> Cell

--- a/src/World.elm
+++ b/src/World.elm
@@ -105,12 +105,7 @@ addLotResident lotId lot world =
             Car.new kind
                 |> Car.withHome lotId
                 |> Car.withPosition lot.entryDetails.parkingSpot
-                |> Car.withOrientation
-                    (lot.content.entryDirection
-                        |> Cell.orthogonalDirectionToLmDirection
-                        |> Direction2d.rotateClockwise
-                        |> Direction2d.toAngle
-                    )
+                |> Car.withOrientation (Lot.parkingSpotOrientation lot)
                 |> Car.build carId (RoadNetwork.findNodeByLotId world.roadNetwork lotId)
 
         addToWorld car =


### PR DESCRIPTION
Make a reasonable effort to keep a car on route if a nearby tile is removed, or a new one is added.