### PR TITLE
Delayed routing

### DIFF
--- a/devtools/PathfindingVisualization.elm
+++ b/devtools/PathfindingVisualization.elm
@@ -1,4 +1,10 @@
-module PathfindingVisualization exposing (Model, Msg, Path, SplineMeta, main)
+module PathfindingVisualization exposing
+    ( Model
+    , Msg
+    , Path
+    , SplineMeta
+    , main
+    )
 
 import Array exposing (Array)
 import Browser
@@ -191,7 +197,7 @@ initialCar =
         |> Car.withPosition initialStart
         |> Car.withOrientation (Direction2d.toAngle initialTangentDirection)
         |> Car.withVelocity Steering.maxVelocity
-        |> Car.build 1 Nothing Nothing
+        |> Car.build 1 Nothing
 
 
 initialModel : Model

--- a/src/Common.elm
+++ b/src/Common.elm
@@ -1,11 +1,11 @@
 module Common exposing
-    ( addMillisecondsToPosix
-    , angleFromDirection
+    ( angleFromDirection
     , boundingBoxOverlaps
     , boundingBoxToFrame
     , boundingBoxWithDimensions
     , isCloseToZeroVelocity
     , isInTheNormalPlaneOf
+    , randomFutureTime
     , rightAnglePosition
     , splitBoundingBoxHorizontally
     , splitBoundingBoxVertically
@@ -19,6 +19,7 @@ import Length exposing (Length)
 import Model.Geometry exposing (LMBoundingBox2d, LMFrame2d, LMPoint2d)
 import Point2d exposing (Point2d)
 import Quantity
+import Random
 import Speed exposing (Speed)
 import Time
 import Vector2d
@@ -180,3 +181,9 @@ isCloseToZeroVelocity =
 addMillisecondsToPosix : Int -> Time.Posix -> Time.Posix
 addMillisecondsToPosix millis time =
     Time.posixToMillis time + millis |> Time.millisToPosix
+
+
+randomFutureTime : ( Int, Int ) -> Time.Posix -> Random.Generator Time.Posix
+randomFutureTime ( minDelay, maxDelay ) now =
+    Random.int minDelay maxDelay
+        |> Random.map (\delay -> addMillisecondsToPosix delay now)

--- a/src/Common.elm
+++ b/src/Common.elm
@@ -1,5 +1,6 @@
 module Common exposing
-    ( angleFromDirection
+    ( andCarry
+    , angleFromDirection
     , boundingBoxOverlaps
     , boundingBoxToFrame
     , boundingBoxWithDimensions
@@ -187,3 +188,16 @@ randomFutureTime : ( Int, Int ) -> Time.Posix -> Random.Generator Time.Posix
 randomFutureTime ( minDelay, maxDelay ) now =
     Random.int minDelay maxDelay
         |> Random.map (\delay -> addMillisecondsToPosix delay now)
+
+
+
+--
+-- Maybe utility
+--
+
+
+andCarry : (a -> Maybe b) -> Maybe a -> Maybe ( a, b )
+andCarry nextFn carried =
+    Maybe.map2 Tuple.pair
+        carried
+        (carried |> Maybe.andThen nextFn)

--- a/src/Data/RuleSetups.elm
+++ b/src/Data/RuleSetups.elm
@@ -46,8 +46,13 @@ connectedRoadsSetup =
         world =
             simpleWorld
 
-        car =
-            buildCar CarA1 (Point2d.meters 10 150) (Angle.degrees 0) Steering.maxVelocity
+        delta =
+            Duration.milliseconds 200
+
+        ( car, _ ) =
+            buildCar CarA1 (Point2d.meters 8 150) (Angle.degrees 0) Steering.maxVelocity
+                |> routeCarByDestination world (Point2d.meters 8 150)
+                |> Traffic.updateCar delta world
 
         otherCars =
             []
@@ -215,11 +220,18 @@ noCollisionSetupDifferentLanes =
         world =
             simpleWorld
 
-        car =
-            buildCar CarA1 (Point2d.meters 12 150) (Angle.degrees 0) Steering.maxVelocity
+        delta =
+            Duration.milliseconds 500
 
-        otherCar =
-            buildCar CarB2 (Point2d.meters 20 153.8) (Angle.degrees 180) Steering.maxVelocity
+        ( car, _ ) =
+            buildCar CarA1 (Point2d.meters 8 150) (Angle.degrees 0) Steering.maxVelocity
+                |> routeCarByDestination world (Point2d.meters 8 150)
+                |> Traffic.updateCar delta world
+
+        ( otherCar, _ ) =
+            buildCar CarB2 (Point2d.meters 24 154) (Angle.degrees 180) Steering.maxVelocity
+                |> routeCarByDestination world (Point2d.meters 24 154)
+                |> Traffic.updateCar delta world
 
         otherCars =
             [ otherCar
@@ -241,18 +253,32 @@ noCollisionSetupIntersection =
 
         car =
             buildCar CarA1 (Point2d.meters 16 134) (Angle.degrees 0) Steering.maxVelocity
+                |> routeCarByDestination world (Point2d.meters 16 134)
 
         otherCar =
-            buildCar CarB2 (Point2d.meters 26 138) (Angle.degrees 90) Steering.maxVelocity
+            buildCar CarB2 (Point2d.meters 26 128) (Angle.degrees 90) Steering.maxVelocity
+
+        routedOtherCar =
+            case
+                positionsToNodes world
+                    [ Point2d.meters 26 128
+                    , Point2d.meters 26 144
+                    ]
+            of
+                Just ( startNode, otherNodes ) ->
+                    otherCar |> routeCarByNodes startNode otherNodes (Length.meters 10)
+
+                Nothing ->
+                    otherCar
 
         otherCars =
-            [ otherCar
+            [ routedOtherCar
             ]
 
         worldWithCars =
             world
                 |> World.setCar car
-                |> World.setCar otherCar
+                |> World.setCar routedOtherCar
     in
     RuleSetup worldWithCars car otherCars
 

--- a/src/Data/RuleSetups.elm
+++ b/src/Data/RuleSetups.elm
@@ -493,8 +493,7 @@ buildCar option position orientation velocity =
         |> Car.withPosition position
         |> Car.withOrientation orientation
         |> Car.withVelocity velocity
-        -- TODO: combine routeCarByDestination with buildCar for easier setup
-        |> Car.build id Nothing Nothing
+        |> Car.build id Nothing
 
 
 routeCarByDestination : World -> LMPoint2d -> Car -> Car
@@ -513,7 +512,8 @@ routeCarByDestination world position car =
                         world.roadNetwork
                         nodeCtx
             in
-            { car | route = route }
+            car
+                |> Car.routed route
                 |> Traffic.applySteering (Duration.milliseconds 16) Steering.none
 
         Nothing ->

--- a/src/EventQueue.elm
+++ b/src/EventQueue.elm
@@ -19,6 +19,28 @@ maxRetryBackoffMillis =
     60 * 1000
 
 
+retryBackoffMillis : Int -> Int
+retryBackoffMillis retriesAmount =
+    case retriesAmount of
+        1 ->
+            30
+
+        2 ->
+            100
+
+        3 ->
+            500
+
+        4 ->
+            1000
+
+        5 ->
+            3000
+
+        _ ->
+            min maxRetryBackoffMillis (retriesAmount * 1000)
+
+
 type EventQueue eventKind
     = EventQueue (PriorityQueue (Event eventKind))
 
@@ -108,7 +130,7 @@ try tryFn event now eventQueue =
                         Time.posixToMillis now
 
                     nextMillis =
-                        millis + min maxRetryBackoffMillis (nextRetryAmount * 1000)
+                        millis + retryBackoffMillis nextRetryAmount
                 in
                 addEvent
                     { kind = event.kind

--- a/src/EventQueue.elm
+++ b/src/EventQueue.elm
@@ -5,6 +5,7 @@ module EventQueue exposing
     , addEvents
     , createEvent
     , empty
+    , retryBackoffMillis
     , toList
     , try
     , update

--- a/src/Message.elm
+++ b/src/Message.elm
@@ -4,10 +4,8 @@ import Browser.Dom
 import Browser.Events exposing (Visibility)
 import Duration exposing (Duration)
 import Html.Events.Extra.Pointer as Pointer
-import Model.Car exposing (CarEvent)
 import Model.Cell exposing (Cell)
 import Model.Debug exposing (DebugLayerKind)
-import Model.Entity exposing (Id)
 import Model.Liikennematto exposing (SimulationState)
 import Task
 import Time
@@ -28,7 +26,6 @@ type Message
       -- Simulation / World
     | SetSimulation SimulationState
     | UpdateTraffic Duration
-    | TrafficUpdated ( List ( Id, CarEvent ), Time.Posix )
     | CheckQueues Time.Posix
     | UpdateEnvironment
     | GenerateEnvironment

--- a/src/Model/Car.elm
+++ b/src/Model/Car.elm
@@ -10,6 +10,7 @@ module Model.Car exposing
     , currentState
     , new
     , routed
+    , routedWithParking
     , shouldWatchTraffic
     , statusDescription
     , triggerDespawn
@@ -90,8 +91,7 @@ type CarState
 
 
 type CarEvent
-    = ParkingStarted
-    | ParkingComplete
+    = ParkingComplete
     | UnparkingComplete
     | DespawnComplete
 
@@ -220,7 +220,7 @@ parking =
                 []
                 (FSM.Condition parkingCompleted)
             ]
-        , entryActions = [ ParkingStarted ]
+        , entryActions = []
         , exitActions = []
         }
 
@@ -393,6 +393,14 @@ shouldWatchTraffic car =
 routed : Route -> Car -> Car
 routed route car =
     { car | route = route }
+
+
+routedWithParking : Route -> ParkingReservation -> Car -> Car
+routedWithParking route parkingReservation car =
+    { car
+        | route = route
+        , parkingReservation = Just parkingReservation
+    }
 
 
 

--- a/src/Model/Car.elm
+++ b/src/Model/Car.elm
@@ -10,6 +10,7 @@ module Model.Car exposing
     , isDespawning
     , isParked
     , new
+    , routed
     , shouldWatchTraffic
     , statusDescription
     , triggerDespawn
@@ -360,8 +361,8 @@ withVelocity velocity car =
     { car | velocity = velocity }
 
 
-build : Int -> Maybe Route -> Maybe ParkingReservation -> NewCar -> Car
-build id route parkingReservation newCar =
+build : Int -> Maybe ParkingReservation -> NewCar -> Car
+build id parkingReservation newCar =
     let
         ( shape, boundingBox ) =
             adjustedShape newCar.make newCar.position newCar.orientation
@@ -378,10 +379,21 @@ build id route parkingReservation newCar =
     , rotation = newCar.rotation
     , shape = shape
     , boundingBox = boundingBox
-    , route = route |> Maybe.withDefault Route.initialRoute
+    , route = Route.initialRoute
     , homeLotId = newCar.homeLotId
     , parkingReservation = parkingReservation
     }
+
+
+
+--
+-- Route
+--
+
+
+routed : Route -> Car -> Car
+routed route car =
+    { car | route = route }
 
 
 

--- a/src/Model/Car.elm
+++ b/src/Model/Car.elm
@@ -92,7 +92,6 @@ type CarState
 type CarEvent
     = ParkingStarted
     | ParkingComplete
-    | UnparkingStarted
     | UnparkingComplete
     | DespawnComplete
 
@@ -144,7 +143,7 @@ unparking =
                 []
                 FSM.Direct
             ]
-        , entryActions = [ UnparkingStarted ]
+        , entryActions = []
         , exitActions = [ UnparkingComplete ]
         }
 

--- a/src/Model/Editor.elm
+++ b/src/Model/Editor.elm
@@ -1,16 +1,11 @@
 module Model.Editor exposing
     ( Editor
-    , PendingTilemapChange
     , ZoomLevel(..)
     , activateCell
     , advanceLongPressTimer
     , clearPointerDownEvent
-    , combineChangedCells
-    , createPendingTilemapChange
     , deactivateCell
-    , hasPendingTilemapChange
     , initial
-    , minTilemapChangeFrequency
     , mouseDetected
     , reset
     , resetLongPressTimer
@@ -22,14 +17,12 @@ module Model.Editor exposing
 
 import Duration exposing (Duration)
 import Html.Events.Extra.Pointer as Pointer
-import Model.Cell as Cell exposing (Cell, CellCoordinates)
+import Model.Cell as Cell exposing (Cell)
 import Quantity
-import Set exposing (Set)
 
 
 type alias Editor =
     { zoomLevel : ZoomLevel
-    , pendingTilemapChange : Maybe PendingTilemapChange
     , activeCell : Maybe Cell
     , longPressTimer : Maybe Duration
     , pointerDownEvent : Maybe Pointer.Event
@@ -43,19 +36,9 @@ type ZoomLevel
     | VeryFar
 
 
-type alias PendingTilemapChange =
-    ( Duration, Set CellCoordinates )
-
-
-minTilemapChangeFrequency : Duration
-minTilemapChangeFrequency =
-    Duration.milliseconds 750
-
-
 initial : Editor
 initial =
     { zoomLevel = Far
-    , pendingTilemapChange = Nothing
     , activeCell = Nothing
     , longPressTimer = Nothing
     , pointerDownEvent = Nothing
@@ -66,8 +49,7 @@ initial =
 reset : Editor -> Editor
 reset editor =
     { editor
-        | pendingTilemapChange = Nothing
-        , activeCell = initial.activeCell
+        | activeCell = initial.activeCell
         , longPressTimer = initial.longPressTimer
         , pointerDownEvent = initial.pointerDownEvent
         , zoomLevel = initial.zoomLevel
@@ -106,31 +88,6 @@ zoomLevelToUIValue zoomLevel =
 
         Near ->
             3
-
-
-createPendingTilemapChange : List Cell -> Editor -> Editor
-createPendingTilemapChange changedCells editor =
-    let
-        pendingTilemapChange =
-            Just
-                ( minTilemapChangeFrequency
-                , combineChangedCells changedCells Set.empty
-                )
-    in
-    { editor | pendingTilemapChange = pendingTilemapChange }
-
-
-combineChangedCells : List Cell -> Set CellCoordinates -> Set CellCoordinates
-combineChangedCells changedCells currentChanges =
-    changedCells
-        |> List.map Cell.coordinates
-        |> Set.fromList
-        |> Set.union currentChanges
-
-
-hasPendingTilemapChange : Editor -> Bool
-hasPendingTilemapChange editor =
-    editor.pendingTilemapChange /= Nothing
 
 
 activateCell : Cell -> Editor -> Editor

--- a/src/Model/Lot.elm
+++ b/src/Model/Lot.elm
@@ -3,17 +3,16 @@ module Model.Lot exposing
     , ParkingReservation
     , ParkingSpot
     , acquireParkingLock
-    , attemptParking
     , build
     , constructionSite
     , findFreeParkingSpot
-    , hasParkingLockSet
     , inBounds
     , parkingPermitted
     , parkingSpotById
     , parkingSpotEligibleForAll
     , parkingSpotEligibleForResident
     , parkingSpotOrientation
+    , prepareParking
     , releaseParkingLock
     , reserveParkingSpot
     , unreserveParkingSpot
@@ -141,13 +140,18 @@ inBounds cell lot =
 --
 
 
-attemptParking : (ParkingSpot -> Bool) -> Lot -> Maybe ParkingSpot
-attemptParking permissionPredicate lot =
-    if hasParkingLockSet lot then
-        Nothing
+prepareParking : (ParkingSpot -> Bool) -> Id -> Lot -> Maybe ( Lot, ParkingSpot )
+prepareParking permissionPredicate carId lot =
+    carry
+        (acquireParkingLock carId lot)
+        (findFreeParkingSpot permissionPredicate)
 
-    else
-        findFreeParkingSpot permissionPredicate lot
+
+carry : Maybe a -> (a -> Maybe b) -> Maybe ( a, b )
+carry carried nextFn =
+    Maybe.map2 Tuple.pair
+        carried
+        (carried |> Maybe.andThen nextFn)
 
 
 
@@ -180,11 +184,6 @@ releaseParkingLock carId lot =
                     )
     in
     { lot | parkingLock = nextParkingLock }
-
-
-hasParkingLockSet : Lot -> Bool
-hasParkingLockSet lot =
-    lot.parkingLock /= Nothing
 
 
 

--- a/src/Model/Lot.elm
+++ b/src/Model/Lot.elm
@@ -142,16 +142,8 @@ inBounds cell lot =
 
 prepareParking : (ParkingSpot -> Bool) -> Id -> Lot -> Maybe ( Lot, ParkingSpot )
 prepareParking permissionPredicate carId lot =
-    carry
-        (acquireParkingLock carId lot)
-        (findFreeParkingSpot permissionPredicate)
-
-
-carry : Maybe a -> (a -> Maybe b) -> Maybe ( a, b )
-carry carried nextFn =
-    Maybe.map2 Tuple.pair
-        carried
-        (carried |> Maybe.andThen nextFn)
+    acquireParkingLock carId lot
+        |> Common.andCarry (findFreeParkingSpot permissionPredicate)
 
 
 

--- a/src/Model/Route.elm
+++ b/src/Model/Route.elm
@@ -30,7 +30,6 @@ import AStar
 import Array exposing (Array)
 import CubicSpline2d exposing (ArcLengthParameterized)
 import Dict exposing (Dict)
-import Duration exposing (Duration)
 import Length exposing (Length)
 import List.Extra as List
 import Model.Entity exposing (Id)
@@ -55,12 +54,11 @@ import Model.RoadNetwork as RoadNetwork
 import Quantity
 import Random
 import Random.List
-import Round
 import Splines
 
 
 type Route
-    = Unrouted (Maybe Duration)
+    = Unrouted
     | Routed RouteMeta
     | ArrivingToDestination Destination Path
 
@@ -100,14 +98,9 @@ maxALPError =
     Length.meters 0.1
 
 
-initialParkingWaitTimer : Maybe Duration
-initialParkingWaitTimer =
-    Just (Duration.milliseconds 1500)
-
-
 initialRoute : Route
 initialRoute =
-    Unrouted initialParkingWaitTimer
+    Unrouted
 
 
 
@@ -373,7 +366,7 @@ isWaitingForRoute : Route -> Bool
 isWaitingForRoute route =
     case route of
         -- Still waiting until a new route is built
-        Unrouted (Just _) ->
+        Unrouted ->
             True
 
         _ ->
@@ -383,7 +376,7 @@ isWaitingForRoute route =
 isRouted : Route -> Bool
 isRouted route =
     case route of
-        Unrouted _ ->
+        Unrouted ->
             False
 
         _ ->
@@ -657,17 +650,8 @@ sampleAheadWithPath path lookAheadAmount currentSplineMeta =
 description : Route -> String
 description route =
     case route of
-        Unrouted timer ->
-            case timer of
-                Just activeTimer ->
-                    String.concat
-                        [ "Unrouted for "
-                        , Duration.inSeconds activeTimer |> Round.round 2
-                        , "s"
-                        ]
-
-                Nothing ->
-                    "Unrouted"
+        Unrouted ->
+            "Unrouted"
 
         Routed routeMeta ->
             String.concat

--- a/src/Model/Route.elm
+++ b/src/Model/Route.elm
@@ -174,8 +174,8 @@ stopAtSplineEnd route =
         |> Maybe.map (ArrivingToDestination RoadNetworkNode)
 
 
-arriveToParkingSpot : ParkingReservation -> Dict Id Lot -> Maybe Route
-arriveToParkingSpot parkingReservation lots =
+arriveToParkingSpot : ParkingReservation -> Dict Id Lot -> Route -> Maybe Route
+arriveToParkingSpot parkingReservation lots route =
     parkingReservation
         |> parkingSpotFromReservation lots
         |> Maybe.map .pathFromLotEntry

--- a/src/Model/World.elm
+++ b/src/Model/World.elm
@@ -50,7 +50,11 @@ import Time
 type WorldEvent
     = SpawnTestCar
     | SpawnResident CarMake Id
-    | RouteCarFromParkingSpot Id Lot.ParkingReservation
+    | CreateRouteFromParkingSpot Id Lot.ParkingReservation
+    | CreateRouteFromNode Id RNNodeContext
+    | BeginCarParking { carId : Id, lotId : Id }
+    | CarStateChange Id Car.CarEvent
+    | None
 
 
 type alias World =
@@ -387,15 +391,7 @@ formatEvents time world =
             (\event ->
                 let
                     kind =
-                        case event.kind of
-                            SpawnTestCar ->
-                                "Spawn test car"
-
-                            SpawnResident _ lotId ->
-                                "Spawn resident: lot #" ++ String.fromInt lotId
-
-                            RouteCarFromParkingSpot carId _ ->
-                                "Router car from parkingSpot #" ++ String.fromInt carId
+                        formatEventKind event.kind
 
                     timeDiff =
                         Time.posixToMillis event.triggerAt - Time.posixToMillis time
@@ -408,3 +404,28 @@ formatEvents time world =
                 in
                 ( kind, timeUntilTrigger, retries )
             )
+
+
+formatEventKind : WorldEvent -> String
+formatEventKind kind =
+    case kind of
+        SpawnTestCar ->
+            "Spawn test car"
+
+        SpawnResident _ lotId ->
+            "Spawn resident: lot #" ++ String.fromInt lotId
+
+        CreateRouteFromParkingSpot carId _ ->
+            "Route car from parkingSpot: #" ++ String.fromInt carId
+
+        CreateRouteFromNode carId _ ->
+            "Route car from node: #" ++ String.fromInt carId
+
+        BeginCarParking { carId, lotId } ->
+            "Begin parking: car #" ++ String.fromInt carId ++ "\nLot #" ++ String.fromInt lotId
+
+        CarStateChange carId _ ->
+            "Car FSM event: #" ++ String.fromInt carId
+
+        None ->
+            "_NONE_"

--- a/src/Model/World.elm
+++ b/src/Model/World.elm
@@ -1,5 +1,6 @@
 module Model.World exposing
-    ( RNLookupEntry
+    ( PendingTilemapChange
+    , RNLookupEntry
     , World
     , WorldEvent(..)
     , addEvent
@@ -12,9 +13,11 @@ module Model.World exposing
     , findNodeByPosition
     , formatEvents
     , hasLot
+    , hasPendingTilemapChange
     , isEmptyArea
     , removeCar
     , removeLot
+    , resolveTilemapUpdate
     , setCar
     , setSeed
     , setTilemap
@@ -25,10 +28,11 @@ import BoundingBox2d
 import Common
 import Data.Cars exposing (CarMake)
 import Dict exposing (Dict)
+import Duration exposing (Duration)
 import EventQueue exposing (EventQueue)
 import Length exposing (Length)
 import Model.Car as Car exposing (Car)
-import Model.Cell exposing (Cell)
+import Model.Cell as Cell exposing (Cell, CellCoordinates)
 import Model.Entity exposing (Id)
 import Model.Geometry exposing (GlobalCoordinates, LMBoundingBox2d, LMPoint2d)
 import Model.Lot as Lot exposing (Lot)
@@ -36,19 +40,22 @@ import Model.RoadNetwork as RoadNetwork exposing (RNNodeContext, RoadNetwork)
 import Model.Tilemap as Tilemap exposing (Tilemap)
 import Model.TrafficLight exposing (TrafficLights)
 import QuadTree exposing (Bounded, QuadTree)
+import Quantity
 import Random
 import Round
-import Set
+import Set exposing (Set)
 import Time
 
 
 type WorldEvent
     = SpawnTestCar
     | SpawnResident CarMake Id
+    | RouteCarFromParkingSpot Id Lot.ParkingReservation
 
 
 type alias World =
     { tilemap : Tilemap
+    , pendingTilemapChange : Maybe PendingTilemapChange
     , roadNetwork : RoadNetwork
     , trafficLights : TrafficLights
     , cars : Dict Id Car
@@ -61,6 +68,10 @@ type alias World =
     }
 
 
+type alias PendingTilemapChange =
+    ( Duration, Set CellCoordinates )
+
+
 type alias RNLookupEntry =
     { id : Int
     , position : LMPoint2d
@@ -71,6 +82,11 @@ type alias RNLookupEntry =
 quadTreeLeafElementsAmount : Int
 quadTreeLeafElementsAmount =
     4
+
+
+minTilemapChangeFrequency : Duration
+minTilemapChangeFrequency =
+    Duration.milliseconds 750
 
 
 initialSeed : Random.Seed
@@ -88,6 +104,7 @@ empty tilemapConfig =
             Tilemap.boundingBox tilemap
     in
     { tilemap = tilemap
+    , pendingTilemapChange = Nothing
     , roadNetwork = RoadNetwork.empty
     , trafficLights = Dict.empty
     , cars = Dict.empty
@@ -167,6 +184,11 @@ findNearbyEntitiesFromPoint radius point quadTree =
         radius
         (BoundingBox2d.singleton point)
         quadTree
+
+
+hasPendingTilemapChange : World -> Bool
+hasPendingTilemapChange editor =
+    editor.pendingTilemapChange /= Nothing
 
 
 
@@ -284,6 +306,77 @@ setSeed seed world =
 
 
 
+--
+-- Tilemap change
+--
+
+
+resolveTilemapUpdate : Duration -> Tilemap.TilemapUpdateResult -> World -> ( World, List Cell )
+resolveTilemapUpdate delta tilemapUpdateResult world =
+    case world.pendingTilemapChange of
+        Nothing ->
+            let
+                nextWorld =
+                    if List.isEmpty tilemapUpdateResult.transitionedCells then
+                        world
+
+                    else
+                        createPendingTilemapChange tilemapUpdateResult.transitionedCells world
+            in
+            ( nextWorld
+            , []
+            )
+
+        Just pendingTilemapChange ->
+            let
+                ( changeTimer, currentChangedCells ) =
+                    pendingTilemapChange
+
+                nextTimer =
+                    if not (List.isEmpty tilemapUpdateResult.transitionedCells) then
+                        -- The tilemap changed during the delay, reset it (AKA debounce)
+                        minTilemapChangeFrequency
+
+                    else
+                        changeTimer
+                            |> Quantity.minus delta
+                            |> Quantity.max Quantity.zero
+
+                nextChangedCells =
+                    combineChangedCells tilemapUpdateResult.transitionedCells currentChangedCells
+            in
+            if Quantity.lessThanOrEqualToZero nextTimer then
+                ( { world | pendingTilemapChange = Nothing }
+                , Cell.fromCoordinatesSet (Tilemap.config world.tilemap) nextChangedCells
+                )
+
+            else
+                ( { world | pendingTilemapChange = Just ( nextTimer, nextChangedCells ) }
+                , []
+                )
+
+
+createPendingTilemapChange : List Cell -> World -> World
+createPendingTilemapChange changedCells editor =
+    let
+        pendingTilemapChange =
+            Just
+                ( minTilemapChangeFrequency
+                , combineChangedCells changedCells Set.empty
+                )
+    in
+    { editor | pendingTilemapChange = pendingTilemapChange }
+
+
+combineChangedCells : List Cell -> Set CellCoordinates -> Set CellCoordinates
+combineChangedCells changedCells currentChanges =
+    changedCells
+        |> List.map Cell.coordinates
+        |> Set.fromList
+        |> Set.union currentChanges
+
+
+
 -- Utility
 
 
@@ -300,6 +393,9 @@ formatEvents time world =
 
                             SpawnResident _ lotId ->
                                 "Spawn resident: lot #" ++ String.fromInt lotId
+
+                            RouteCarFromParkingSpot carId _ ->
+                                "Router car from parkingSpot #" ++ String.fromInt carId
 
                     timeDiff =
                         Time.posixToMillis event.triggerAt - Time.posixToMillis time

--- a/src/Simulation/Collision.elm
+++ b/src/Simulation/Collision.elm
@@ -57,7 +57,7 @@ fovRadius =
 
 checkFutureCollision : Car -> Car -> CollisionCheckResult
 checkFutureCollision activeCar otherCar =
-    if Car.isParked activeCar then
+    if Car.currentState activeCar == Car.Parked then
         NoCollision
 
     else

--- a/src/Simulation/Events.elm
+++ b/src/Simulation/Events.elm
@@ -41,7 +41,7 @@ processEvent time event world =
             case World.findLotById lotId world of
                 Just lot ->
                     withRetry
-                        (spawnResident time carMake lot world)
+                        (spawnResident time carMake lot)
                         time
                         event
                         world
@@ -62,7 +62,7 @@ processEvent time event world =
             withCar
                 (\car _ ->
                     withRetry
-                        (attemptGenerateRouteFromParkingSpot car parkingReservation world)
+                        (attemptGenerateRouteFromParkingSpot car parkingReservation)
                         time
                         event
                         world
@@ -74,7 +74,7 @@ processEvent time event world =
             withCar
                 (\car _ ->
                     withRetry
-                        (attemptGenerateRouteFromNode car startNodeCtx world)
+                        (attemptGenerateRouteFromNode car startNodeCtx)
                         time
                         event
                         world
@@ -93,7 +93,7 @@ processEvent time event world =
                             World.setCar carWithPendingStateChange world
                     in
                     withRetry
-                        (attemptBeginParking carWithPendingStateChange lotId updatedWorld)
+                        (attemptBeginParking carWithPendingStateChange lotId)
                         time
                         event
                         updatedWorld
@@ -242,11 +242,11 @@ setupRespawn time =
 --
 
 
-withRetry : Result String World -> Time.Posix -> EventQueue.Event WorldEvent -> World -> World
-withRetry result time event world =
+withRetry : (World -> Result String World) -> Time.Posix -> EventQueue.Event WorldEvent -> World -> World
+withRetry resultFn time event world =
     world.eventQueue
         |> EventQueue.try
-            (\_ -> result)
+            (\_ -> resultFn world)
             event
             time
         |> Result.Extra.extract

--- a/src/Simulation/Events.elm
+++ b/src/Simulation/Events.elm
@@ -132,7 +132,10 @@ attemptGenerateRouteFromNode car startNodeCtx world =
         Result.Err "Can't generate route while tilemap change is pending"
 
     else
-        generateRouteFromNode world car startNodeCtx
+        -- Room for improvement: this step is not required once nodes have stable IDs
+        World.findNodeByPosition world startNodeCtx.node.label.position
+            |> Result.fromMaybe "Could not find the start node"
+            |> Result.andThen (generateRouteFromNode world car)
             |> Result.map (\route -> Car.routed route car)
             |> Result.map (\routedCar -> World.setCar routedCar world)
 

--- a/src/Simulation/Pathfinding.elm
+++ b/src/Simulation/Pathfinding.elm
@@ -154,7 +154,7 @@ updateRoute delta car =
                     routeMeta.endNode.node.label.kind
                 of
                     LotEntry lotId ->
-                        ( nextRoute
+                        ( Route.Unrouted
                         , if Car.currentState car == Car.Driving then
                             World.BeginCarParking { carId = car.id, lotId = lotId }
 

--- a/src/Simulation/Traffic.elm
+++ b/src/Simulation/Traffic.elm
@@ -281,6 +281,9 @@ spawnTestCar world =
                 ( world
                     |> World.setCar car
                     |> World.setSeed nextSeed
+                    |> World.addEvent
+                        (World.CreateRouteFromNode car.id nodeCtx)
+                        (Time.millisToPosix 0)
                 , Just id
                 )
             )

--- a/tests/TrafficTests.elm
+++ b/tests/TrafficTests.elm
@@ -33,9 +33,9 @@ suite =
     describe "Round"
         [ describe "Collision rules"
             [ test "allow movement if there will be no collision (straight road, different lanes)"
-                (\_ -> Expect.equal (Traffic.checkRules noCollisionSetupDifferentLanes) Steering.none)
+                (\_ -> Expect.equal (Traffic.checkRules noCollisionSetupDifferentLanes) Steering.accelerate)
             , test "allow movement if there will be no collision (intersection)"
-                (\_ -> Expect.equal (Traffic.checkRules noCollisionSetupIntersection) Steering.none)
+                (\_ -> Expect.equal (Traffic.checkRules noCollisionSetupIntersection) Steering.accelerate)
             , test "disallow movement if it will cause a collision (paths intersect)"
                 (\_ ->
                     Expect.true
@@ -61,7 +61,7 @@ suite =
             ]
         , describe "Intersection rules"
             [ test "allow movement if the car is not facing a intersection"
-                (\_ -> Expect.equal (Traffic.checkRules connectedRoadsSetup) Steering.none)
+                (\_ -> Expect.equal (Traffic.checkRules connectedRoadsSetup) Steering.accelerate)
             , test "allow movement if traffic lights are green"
                 (\_ ->
                     Expect.true


### PR DESCRIPTION
Use the event queue to delay routing. This will spread the load more evenly and make the cars have realistic pauses at lots. The new routing orchestration simplifies the car FSM. Car FSM events are now handles as World events.